### PR TITLE
Fix negative counter number issue

### DIFF
--- a/js/a2x-text-counter.jquery.plugin.js
+++ b/js/a2x-text-counter.jquery.plugin.js
@@ -6,7 +6,12 @@ $.fn.a2xCounter = function() {
 
   this.on('keyup', function(e) {
     if (max > 0) {
-      counter.html(max - ($(this).val().length + ($(this).val().split("\n").length - 1)));
+      var textLength = $(this).val().length + ($(this).val().split("\n").length - 1);
+      if (max - textLength >= 0) {
+        counter.html(max - textLength);
+      } else {
+        counter.html(0);
+      }
     } else {
       counter.html($(this).val().length + ($(this).val().split("\n").length - 1));
     }


### PR DESCRIPTION
Hello. The counter will be negative under some conditions, for example:
- Set `maxlength` to 10
- Type 9 letters and press enter key, then counter becomes -1  

Is `0` more reasonable?
